### PR TITLE
Einige Änderungen (CSS und Pfeilnavigation engl.)

### DIFF
--- a/cntr-monitor/src/components/Post.js
+++ b/cntr-monitor/src/components/Post.js
@@ -172,25 +172,28 @@ export default function Post({ data, pageContext, children }) {
       return found !== -1
     })
   }
+
   const next = posts[currentIndex + 1] || null
   const previous = posts[currentIndex - 1] || null
+// media machine: "previous" and "next" relative path wrong? '/2024/' instead of '../' for the english version.
+  // The problem is not yet solved, just patched up
+    const pagination = (
+      <nav className={styles.pagination}>
+        {previous && (
+          <Link className={`${styles.paginationPrev} ${styles.paginationLink}`} rel="prev" to={`/2024/${previous.childMdx.fields.slug}`}>
+            <Arrow/>
+            <span>{t('Previous')}  </span>
+          </Link>
+        )}
+        {next && (
+          <Link className={`${styles.paginationLink}`} rel="next" to={`/2024/${next.childMdx.fields.slug}`}>
+            <Arrow/>
 
-  const pagination = (
-    <nav className={styles.pagination}>
-      {previous && (
-        <Link className={`${styles.paginationPrev} ${styles.paginationLink}`} rel="prev" to={`../${previous.childMdx.fields.slug}`}>
-          <Arrow />
-          <span>{t('Previous')}</span>
-        </Link>
-      )}
-      {next && (
-        <Link className={`${styles.paginationLink}`} rel="next" to={`../${next.childMdx.fields.slug}`}>
-          <Arrow />
-          <span>{t('Next')}</span>
-        </Link>
-      )}
-    </nav>
-  )
+            <span>{t('Next')} ${next.childMdx.fields.slug}</span>
+          </Link>
+        )}
+      </nav>
+    )
 
   const translationData = {
     translations: data.translations.nodes,

--- a/cntr-monitor/src/components/Post.js
+++ b/cntr-monitor/src/components/Post.js
@@ -176,7 +176,7 @@ export default function Post({ data, pageContext, children }) {
   const next = posts[currentIndex + 1] || null
   const previous = posts[currentIndex - 1] || null
 // media machine: "previous" and "next" relative path wrong? '/2024/' instead of '../' for the english version.
-  // The problem is not yet solved, just patched up
+  // The problem is not yet solved, just patched up.
     const pagination = (
       <nav className={styles.pagination}>
         {previous && (

--- a/cntr-monitor/src/components/Post.js
+++ b/cntr-monitor/src/components/Post.js
@@ -252,7 +252,7 @@ export function Head({ data, pageContext, location }) {
   }
   const { primary, dark, light, knockout } = useColors(
     data.issue.childMdx.frontmatter.color,
-    ['Analyse', 'Analysis', 'Anhang', 'Appendix'].includes(data.post.childMdx.frontmatter.category)
+    ['Analyse', 'Analysen', 'Analysis', 'Focus', 'Fokus', 'Anhang', 'Appendix'].includes(data.post.childMdx.frontmatter.category)
   )
 
   const bodyStyles = {

--- a/cntr-monitor/src/components/_vars.scss
+++ b/cntr-monitor/src/components/_vars.scss
@@ -158,3 +158,23 @@
   letter-spacing: 0.065em;
   word-spacing: 0.02em;
 }
+table{
+  text-align: left;
+  font-size: small;
+  border: 1px solid;
+
+  tr{
+    vertical-align: top;
+  }
+  th,td{
+    border: 1px solid;
+    padding: 5px 5px;
+  }
+  thead{
+    tr{
+      font-size: var(--ms-0);
+      background: var(--fc-light);
+      border-bottom: 1px solid;
+    }
+  }
+}

--- a/cntr-monitor/src/components/_vars.scss
+++ b/cntr-monitor/src/components/_vars.scss
@@ -161,18 +161,19 @@
 table{
   text-align: left;
   font-size: small;
+  line-height: 1.1rem;
   border: 1px solid;
-
+  margin-bottom: 0.5rem;
   tr{
     vertical-align: top;
   }
   th,td{
     border: 1px solid;
-    padding: 5px 5px;
+    padding: 15px 5px;
   }
   thead{
     tr{
-      font-size: var(--ms-0);
+      font-weight: bold;
       background: var(--fc-light);
       border-bottom: 1px solid;
     }

--- a/cntr-monitor/src/components/global.scss
+++ b/cntr-monitor/src/components/global.scss
@@ -154,7 +154,7 @@ img {
     word-break: break-word;
     display: inline-block;
     position: relative;
-    padding-left: 1em;
+    padding-left: 1.5em;
     width: 100%;
     border-radius: 3px;
     &:target {


### PR DESCRIPTION
**links/rechts-Pfeil-Navigation** zwischen Artikeln funktioniert in der engl. Sprachversion nicht (bitte testen)
**Tabelle** ein bisschen ausgestalten
**Fußnoten:** bisschen mehr Abstand zwischen Zahlen und Fußnotentext
**Farbgebung:** Category "Analyse" (blau) sollte "Analysen" heißen und trotzdem blau ausgegeben werden. "Fokus" sollte auch blau sein. 